### PR TITLE
Add openssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.14.0+1.1.1j"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2329,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3598,6 +3608,7 @@ dependencies = [
  "monero",
  "monero-harness",
  "monero-rpc",
+ "openssl",
  "pem",
  "port_check",
  "prettytable-rs",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -31,6 +31,7 @@ libp2p-async-await = { git = "https://github.com/comit-network/rust-libp2p-async
 miniscript = { version = "5", features = ["serde"] }
 monero = { version = "0.10", features = ["serde_support"] }
 monero-rpc = { path = "../monero-rpc" }
+openssl = { version = "0.10", features = ["vendored"] }
 pem = "0.8"
 prettytable-rs = "0.8"
 rand = "0.7"


### PR DESCRIPTION
potential fix for:

```
...
   Compiling rand_isaac v0.1.1
   Compiling rand_hc v0.1.0
   Compiling rand_xorshift v0.1.1
   Compiling unicode-normalization v0.1.16
error: failed to run custom build command for `openssl-sys v0.9.60`

Caused by:
  process didn't exit successfully: `/home/runner/work/xmr-btc-swap/xmr-btc-swap/target/release/build/openssl-sys-cdc0123f6943de70/build-script-main` (exit code: 101)
  --- stdout
  cargo:rustc-cfg=const_fn
  cargo:rerun-if-env-changed=ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR
  ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR
  ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR
  ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_armv7-unknown-linux-gnueabihf
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_armv7_unknown_linux_gnueabihf
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_armv7-unknown-linux-gnueabihf
  cargo:rerun-if-env-changed=PKG_CONFIG_armv7_unknown_linux_gnueabihf
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_armv7-unknown-linux-gnueabihf
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_armv7_unknown_linux_gnueabihf
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  run pkg_config fail: "pkg-config has not been configured to support cross-compilation.\n\n                Install a sysroot for the target platform and configure it via\n                PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_PATH, or install a\n                cross-compiling wrapper for pkg-config and set it via\n                PKG_CONFIG environment variable."

  --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = armv7-unknown-linux-gnueabihf
  openssl-sys = 0.9.60

  ', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.60/build/find_normal.rs:173:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
Error: Process completed with exit code 101.
```


https://www.reddit.com/r/rust/comments/axaq9b/opensslsys_error_when_crosscompiling_for/
